### PR TITLE
Installation of Eclipse Plugin change from Software updates to Eclipse Marketplace

### DIFF
--- a/core/doc/help/html/userdoc/javatuto/index.html
+++ b/core/doc/help/html/userdoc/javatuto/index.html
@@ -185,26 +185,10 @@ might want to download only the binary runtime, but you will have to
 follow more links. Once you have Eclipse, unzip it on your computer and
 that's it: eclipse has a Java plugin to help you program in Java.</p>
 <p>Now we will install the LibreOffice development plugin for
-Eclipse using the Eclipse software update system. <span class="strong"><strong>Do
-not try to download an archive somewhere: Eclipse will do it for you
-during the next steps.</strong></span> Select the <span class="strong"><strong>Help
-&gt; Software updates &gt; Find and install</strong></span> menu to get the window of
-the illustration <a href="index.html#refIllustration1"
-	title='Figure 2.: "Find &amp; Install" window'>2</a>. Check the second
-option on this window and click on the <span class="strong"><strong>Next</strong></span>
-button.</p>
-<div class="figure"><a name="refIllustration1"></a>
-<p class="title"><b>Figure 2.: "Find &amp; Install" window</b></p>
-<div class="mediaobject">
-<table border="0" summary="manufactured viewport for HTML img"
-	cellspacing="0" cellpadding="0" width="384">
-	<tr style="height: 244px">
-		<td><img src="img/img001.png" height="244"
-			alt=': "Find &amp; Install" window'></td>
-	</tr>
-</table>
-</div>
-</div>
+Eclipse using the <a href=https://marketplace.eclipse.org/content/loeclipse>Eclipse Marketplace</a>.<br/><br/>
+<a href="http://marketplace.eclipse.org/marketplace-client-intro?mpc_install=2881446" class="drag" title="Drag to your running Eclipse workspace to install LOEclipse"><img class="img-responsive" src="https://marketplace.eclipse.org/sites/all/themes/solstice/public/images/marketplace/btn-install.png" alt="Drag to your running Eclipse workspace to install LOEclipse" style="margin-left:100px"/></a>
+<br/>
+
 <p>On the following page, you will see a list of &#8220;<span
 	class="emphasis"><em>update sites</em></span>&#8221;. These are URLs
 pointing to directories containing plugins informations and archives.


### PR DESCRIPTION
In previous versions of Eclipse Plugins were installed from Software Update; Now it is installed from Eclipse Marketplace. 