### PR TITLE
 Fix #62 Null Pointer Exception when trying to export Extension Projects

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -237,7 +237,7 @@ public class UnoPackageExportPage extends WizardPage {
                 String path = dlg.open();
                 if (path != null) {
                     if(!path.substring(path.length()-4).equalsIgnoreCase(".oxt")){
-                        path = path + ".oxt";
+                        path += ".oxt";
                     }
                     mDestinationCombo.setText(path);
                 }

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -233,8 +233,12 @@ public class UnoPackageExportPage extends WizardPage {
             @Override
             public void widgetSelected(SelectionEvent pE) {
                 FileDialog dlg = new FileDialog(getShell(), SWT.SAVE);
+                dlg.setFilterExtensions(new String[] { "*.oxt"});
                 String path = dlg.open();
                 if (path != null) {
+                    if(!path.substring(path.length()-4).equalsIgnoreCase(".oxt")){
+                        path = path + ".oxt";
+                    }
                     mDestinationCombo.setText(path);
                 }
             }

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -144,8 +144,10 @@ public class UnoPackageExportPage extends WizardPage {
             }
             i++;
         }
-
-        mContentSelector.loadDefaults();
+        
+        if(selected!=false){
+            mContentSelector.loadDefaults();
+        }
 
         restoreWidgetValues();
     }


### PR DESCRIPTION
Fix #62 Null Pointer Exception when trying to export Extension Projects: 
Solution : A function which loads certain values is put inside an if condition, thus stopping the null pointer exception