### PR TITLE
Fix #62 Null Pointer Exception when trying to export Extension Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,14 @@ Feel free to join [#libreoffice-dev on freenode](https://irc.documentfoundation.
 2. Clone this repository
 3. Import the three projects `build`, `core` and `java` (using *File->Import->General->Existing projects into workspace*)
 4. Add the LibreOffice jars to the build path
-  * Go to *Preferences* in Eclipse and open the *Java->Build path->User Library* configuration page.
-  * Add a new library named `LO-Classes`
-  * Select the Library, click *Add External Jars*
-  * Search for the LibreOffice jars `unoil.jar juh.jar jurt.jar ridl.jar unoloader.jar`. You find them here:
-    * macOS: `/Applications/LibreOffice.app/Contents/Resources/java`
-    * Ubuntu: `/usr/lib/libreoffice/program/classes`
-    * Windows: `C:\Program Files\LibreOffice 5\program\classes\`
-  * Now there should be no more project errors.
+   * Go to *Preferences* in Eclipse and open the *Java->Build path->User Library* configuration page.
+   * Add a new library named `LO-Classes`
+   * Select the Library, click *Add External Jars*
+   * Search for the LibreOffice jars `unoil.jar juh.jar jurt.jar ridl.jar unoloader.jar`. You find them here:
+     * macOS: `/Applications/LibreOffice.app/Contents/Resources/java`
+     * Ubuntu: `/usr/lib/libreoffice/program/classes`
+     * Windows: `C:\Program Files\LibreOffice 5\program\classes\`
+   * Now there should be no more project errors.
 5. Go to *Run->Run Configurations*, and create a new run configuration of the type *Eclipse Application*. Now you can run or debug the LOEclipse plugin using this run configuration.
 
 ## Release Management

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Developer and User Documentation is found in [core/doc/help/html](https://github
 
 Feel free to join [#libreoffice-dev on freenode](https://irc.documentfoundation.org/?settings=#libreoffice-dev) to get in touch with LibreOffice and LOEclipse developers.
 
+You can also write to the [LibreOffice development mailing list](https://lists.freedesktop.org/mailman/listinfo/libreoffice) if you have trouble working on this project.
+
 ### Prerequisites
 
 * Ubuntu: Install `libreoffice`,`libreoffice-dev` and `libreoffice-java-common`.
@@ -38,13 +40,13 @@ Feel free to join [#libreoffice-dev on freenode](https://irc.documentfoundation.
 2. Clone this repository
 3. Import the three projects `build`, `core` and `java` (using *File->Import->General->Existing projects into workspace*)
 4. Add the LibreOffice jars to the build path
-   * Go to *Preferences* in Eclipse and open the *Java->Build path->User Library* configuration page.
+   * Go to *Window->Preferences* in Eclipse and open the *Java->Build path->User Libraries* configuration page.
    * Add a new library named `LO-Classes`
    * Select the Library, click *Add External Jars*
-   * Search for the LibreOffice jars `unoil.jar juh.jar jurt.jar ridl.jar unoloader.jar`. You find them here:
+   * Add the LibreOffice jars `unoil.jar juh.jar jurt.jar ridl.jar unoloader.jar`. You find them here:
      * macOS: `/Applications/LibreOffice.app/Contents/Resources/java`
      * Ubuntu: `/usr/lib/libreoffice/program/classes`
-     * Windows: `C:\Program Files\LibreOffice 5\program\classes\`
+     * Windows: `C:\Program Files[ (x86)]\LibreOffice 5\program\classes\`
    * Now there should be no more project errors.
 5. Go to *Run->Run Configurations*, and create a new run configuration of the type *Eclipse Application*. Now you can run or debug the LOEclipse plugin using this run configuration.
 

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -145,7 +145,9 @@ public class UnoPackageExportPage extends WizardPage {
             i++;
         }
 
-        mContentSelector.loadDefaults();
+        if(selected!=false){
+            mContentSelector.loadDefaults();
+        }
 
         restoreWidgetValues();
     }

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -145,7 +145,7 @@ public class UnoPackageExportPage extends WizardPage {
             i++;
         }
 
-        if(selected!=false){
+        if(selected) {
             mContentSelector.loadDefaults();
         }
 


### PR DESCRIPTION
The exception was fixed when a particular function which was being called even when there were no Extension Projects was put under proper if condition