### PR TITLE
Loeclipse branch 5,  Fix #21: RegistrationHandler.classes sometimes empty.

### DIFF
--- a/java/source/org/libreoffice/ide/eclipse/java/JavaResourceDeltaVisitor.java
+++ b/java/source/org/libreoffice/ide/eclipse/java/JavaResourceDeltaVisitor.java
@@ -105,7 +105,7 @@ public class JavaResourceDeltaVisitor implements IResourceDeltaVisitor {
     private void removeImplementation(IResourceDelta pDelta,
         IUnoidlProject pUnoprj) {
         IResource res = pDelta.getResource();
-        if (res.getName().endsWith(".java")) { //$NON-NLS-1$
+        if (res.getName().endsWith(".java")) { //$NON-NLS-1$ 
             String prjPath = pDelta.getProjectRelativePath().toString();
             prjPath = prjPath.replace(".java", ""); //$NON-NLS-1$ //$NON-NLS-2$
             prjPath = prjPath.replace("/", "."); //$NON-NLS-1$ //$NON-NLS-2$
@@ -116,6 +116,8 @@ public class JavaResourceDeltaVisitor implements IResourceDeltaVisitor {
                     RegistrationHelper.removeImplementation(pUnoprj, implName);
                 }
             }
+        } else if (res.getName().endsWith(".jar")) {
+            RegistrationHelper.isFileEmpty(pUnoprj);
         }
     }
 

--- a/java/source/org/libreoffice/ide/eclipse/java/JavaResourceDeltaVisitor.java
+++ b/java/source/org/libreoffice/ide/eclipse/java/JavaResourceDeltaVisitor.java
@@ -105,7 +105,7 @@ public class JavaResourceDeltaVisitor implements IResourceDeltaVisitor {
     private void removeImplementation(IResourceDelta pDelta,
         IUnoidlProject pUnoprj) {
         IResource res = pDelta.getResource();
-        if (res.getName().endsWith(".java")) { //$NON-NLS-1$ 
+        if (res.getName().endsWith(".java")) { //$NON-NLS-1$
             String prjPath = pDelta.getProjectRelativePath().toString();
             prjPath = prjPath.replace(".java", ""); //$NON-NLS-1$ //$NON-NLS-2$
             prjPath = prjPath.replace("/", "."); //$NON-NLS-1$ //$NON-NLS-2$

--- a/java/source/org/libreoffice/ide/eclipse/java/registration/RegistrationHelper.java
+++ b/java/source/org/libreoffice/ide/eclipse/java/registration/RegistrationHelper.java
@@ -56,10 +56,10 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.dialogs.MessageDialog;
+import org.eclipse.swt.widgets.Display;
 import org.libreoffice.ide.eclipse.core.PluginLogger;
 import org.libreoffice.ide.eclipse.core.model.IUnoidlProject;
 import org.libreoffice.ide.eclipse.java.utils.TemplatesHelper;
-import org.eclipse.swt.widgets.Display;
 
 /**
  * This class provides utility methods to generate the class and files needed
@@ -76,6 +76,7 @@ public abstract class RegistrationHelper {
      * @param pProject the project where to create the registration handler
      */
     public static void generateFiles(IUnoidlProject pProject) {
+
         // Copy the RegistrationHandler.java.tpl file
         TemplatesHelper.copyTemplate(pProject, CLASS_FILENAME + TemplatesHelper.JAVA_EXT,
             RegistrationHelper.class, new String());
@@ -146,6 +147,7 @@ public abstract class RegistrationHelper {
      * @return the implementation classes list
      */
     public static Vector<String> readClassesList(IUnoidlProject pProject) {
+
         Vector<String> classes = new Vector<String>();
 
         IFile list = getClassesListFile(pProject);
@@ -191,6 +193,7 @@ public abstract class RegistrationHelper {
      * @param pClasses the classes to write
      */
     private static void writeClassesList(IUnoidlProject pProject, Vector<String> pClasses) {
+
         IFile list = getClassesListFile(pProject);
         File file = list.getLocation().toFile();
 
@@ -224,15 +227,16 @@ public abstract class RegistrationHelper {
         // Get the path where to place the class and the implementations list
         IPath relPath = pProject.getImplementationPath();
         IFolder dest = pProject.getFolder(relPath);
+
         return dest.getFile("RegistrationHandler.classes"); //$NON-NLS-1$
     }
 
     /**
-        * Check if the RegistrationHandler.classes file is empty
-        * <code>org.libreoffice.ide.eclipse.java.JavaResourceDeltaVisitor</code>
-        *
-        * @param pProject the project where to check empty file
-        */
+     * Check if the RegistrationHandler.classes file is empty
+     * <code>org.libreoffice.ide.eclipse.java.JavaResourceDeltaVisitor</code>
+     *
+     * @param pProject the project where to check empty file
+     */
     public static void isFileEmpty(IUnoidlProject pProject) {
         IFile list = getClassesListFile(pProject);
         File file = list.getLocation().toFile();

--- a/java/source/org/libreoffice/ide/eclipse/java/registration/RegistrationHelper.java
+++ b/java/source/org/libreoffice/ide/eclipse/java/registration/RegistrationHelper.java
@@ -55,9 +55,11 @@ import java.util.Vector;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.runtime.IPath;
+import org.eclipse.jface.dialogs.MessageDialog;
 import org.libreoffice.ide.eclipse.core.PluginLogger;
 import org.libreoffice.ide.eclipse.core.model.IUnoidlProject;
 import org.libreoffice.ide.eclipse.java.utils.TemplatesHelper;
+import org.eclipse.swt.widgets.Display;
 
 /**
  * This class provides utility methods to generate the class and files needed
@@ -74,7 +76,6 @@ public abstract class RegistrationHelper {
      * @param pProject the project where to create the registration handler
      */
     public static void generateFiles(IUnoidlProject pProject) {
-
         // Copy the RegistrationHandler.java.tpl file
         TemplatesHelper.copyTemplate(pProject, CLASS_FILENAME + TemplatesHelper.JAVA_EXT,
             RegistrationHelper.class, new String());
@@ -145,7 +146,6 @@ public abstract class RegistrationHelper {
      * @return the implementation classes list
      */
     public static Vector<String> readClassesList(IUnoidlProject pProject) {
-
         Vector<String> classes = new Vector<String>();
 
         IFile list = getClassesListFile(pProject);
@@ -191,7 +191,6 @@ public abstract class RegistrationHelper {
      * @param pClasses the classes to write
      */
     private static void writeClassesList(IUnoidlProject pProject, Vector<String> pClasses) {
-
         IFile list = getClassesListFile(pProject);
         File file = list.getLocation().toFile();
 
@@ -225,7 +224,43 @@ public abstract class RegistrationHelper {
         // Get the path where to place the class and the implementations list
         IPath relPath = pProject.getImplementationPath();
         IFolder dest = pProject.getFolder(relPath);
-
         return dest.getFile("RegistrationHandler.classes"); //$NON-NLS-1$
+    }
+
+    /**
+        * Check if the RegistrationHandler.classes file is empty
+        * <code>org.libreoffice.ide.eclipse.java.JavaResourceDeltaVisitor</code>
+        *
+        * @param pProject the project where to check empty file
+        */
+    public static void isFileEmpty(IUnoidlProject pProject) {
+        IFile list = getClassesListFile(pProject);
+        File file = list.getLocation().toFile();
+        boolean checkFileEmpty = true;
+        FileInputStream in = null;
+        BufferedReader reader = null;
+        try {
+            in = new FileInputStream(file);
+            reader = new BufferedReader(new InputStreamReader(in));
+            if (reader.readLine() == null) {
+                checkFileEmpty = true;
+            } else {
+                checkFileEmpty = false;
+            }
+        } catch (Exception e) {
+            checkFileEmpty = true;
+
+        } finally {
+            try {
+                reader.close();
+                in.close();
+            } catch (Exception e) {
+            }
+        }
+        if (checkFileEmpty) {
+            PluginLogger.error(Messages.getString("RegistrationHelper.RegistrationHandlerEmptyClassError"));
+            MessageDialog.openError(Display.getDefault().getActiveShell(), "Error",
+                Messages.getString("RegistrationHelper.RegistrationHandlerEmptyClassError"));
+        }
     }
 }

--- a/java/source/org/libreoffice/ide/eclipse/java/registration/messages.properties
+++ b/java/source/org/libreoffice/ide/eclipse/java/registration/messages.properties
@@ -1,2 +1,3 @@
 FileRefreshJob.Error=Can't refresh the registration classes file
 RegistrationHelper.WriteClassesListError=Error during classes list writing
+RegistrationHelper.RegistrationHandlerEmptyClassError=The RegistrationHandler.classes is empty, exported .oxt extension will not work properly 

--- a/java/source/org/libreoffice/ide/eclipse/java/registration/messages.properties
+++ b/java/source/org/libreoffice/ide/eclipse/java/registration/messages.properties
@@ -1,3 +1,4 @@
 FileRefreshJob.Error=Can't refresh the registration classes file
 RegistrationHelper.WriteClassesListError=Error during classes list writing
-RegistrationHelper.RegistrationHandlerEmptyClassError=The RegistrationHandler.classes is empty, exported .oxt extension will not work properly 
+RegistrationHelper.RegistrationHandlerEmptyClassError=The RegistrationHandler.classes is empty, exported .oxt extension will not work properly
+ 


### PR DESCRIPTION
Fix #21: RegistrationHandler.classes sometimes empty.  
Solution : During .oxt export shows an error message when RegistrationHandler.classes is empty