### PR TITLE
Revert changes : OXT Export: Automatically add .oxt extension #51

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -235,12 +235,8 @@ public class UnoPackageExportPage extends WizardPage {
             @Override
             public void widgetSelected(SelectionEvent pE) {
                 FileDialog dlg = new FileDialog(getShell(), SWT.SAVE);
-                dlg.setFilterExtensions(new String[] { "*.oxt" });
                 String path = dlg.open();
                 if (path != null) {
-                    if (!path.substring(path.length() - 4).equalsIgnoreCase(".oxt")) {
-                        path += ".oxt";
-                    }
                     mDestinationCombo.setText(path);
                 }
             }

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -235,6 +235,7 @@ public class UnoPackageExportPage extends WizardPage {
             @Override
             public void widgetSelected(SelectionEvent pE) {
                 FileDialog dlg = new FileDialog(getShell(), SWT.SAVE);
+                dlg.setFilterExtensions(new String[] { "*.oxt" });
                 String path = dlg.open();
                 if (path != null) {
                     mDestinationCombo.setText(path);


### PR DESCRIPTION
The changes made was not required since during the creation of the UnoPackage which ultimately results in the ".oxt" file this has been handled in **org.libreoffice.plugin.core.model.UnoPackage.java**

public UnoPackage(File pOut) {
        File dest = pOut;
        if (!(dest.getName().endsWith(ZIP) || dest.getName().endsWith(UNOPKG) || dest.getName().endsWith(OXT))) {
            int pos = dest.getName().lastIndexOf(".");
            if (pos > 0) {
                String name = dest.getName().substring(0, pos);
                dest = new File(dest.getParentFile(), name + "." + OXT);
            } else {
                dest = new File(dest.getParentFile(), dest.getName() + "." + OXT);
            }
        }
 
        mDestination = dest;
        mManifest = new ManifestModel();
    }