### PR TITLE
bugfix: walking libs subfolder on uno package creation

### DIFF
--- a/java/source/org/libreoffice/ide/eclipse/java/JavaBuilder.java
+++ b/java/source/org/libreoffice/ide/eclipse/java/JavaBuilder.java
@@ -352,11 +352,11 @@ public class JavaBuilder implements ILanguageBuilder {
         List<IFile> libs = new ArrayList<>();
         IFolder libFolder = javaProject.getProject().getFolder(LIBS_DIR_NAME);
         if (libFolder.exists()) {
-            IPath rawLoc = libFolder.getRawLocation();
-            String libFolderOsString = rawLoc.toOSString();
-            try (Stream<java.nio.file.Path> walk = Files.walk(Paths.get(libFolderOsString))) {
+            java.nio.file.Path pathLibs = Paths.get(libFolder.getRawLocation().toOSString());
+            try (Stream<java.nio.file.Path> walk = Files.walk(pathLibs)) {
                 libs = walk.map(jarFile -> {
-                    return libFolder.getFile(jarFile.getFileName().toString());
+                    java.nio.file.Path pathRelative = pathLibs.relativize(jarFile);
+                    return libFolder.getFile(pathRelative.toString());
                 }).filter(f -> f.getFileExtension() != null && f.getFileExtension().equalsIgnoreCase("jar"))
                     .collect(Collectors.toList());
             } catch (IOException e) {
@@ -364,6 +364,7 @@ public class JavaBuilder implements ILanguageBuilder {
                     Messages.getString("JavaBuilder.GetExternalLibsFailed"), e);
             }
         }
+        PluginLogger.debug("Found " + libs.size() + " Jars");
         return libs;
     }
 }


### PR DESCRIPTION
https://github.com/LibreOffice/loeclipse/issues/85