### PR TITLE
Enhancing Node Path Manipulation Efficiency using += in OpenOfficeConfiguration.java

### DIFF
--- a/java/source/com/artofsolving/jodconverter/openoffice/connection/OpenOfficeConfiguration.java
+++ b/java/source/com/artofsolving/jodconverter/openoffice/connection/OpenOfficeConfiguration.java
@@ -42,7 +42,7 @@ public class OpenOfficeConfiguration {
 
     public String getOpenOfficeProperty(String nodePath, String node) {
         if (!nodePath.startsWith("/")) {
-            nodePath = "/" + nodePath;
+            nodePath += "/";
         }
         String property = "";
         // create the provider and remember it as a XMultiServiceFactory


### PR DESCRIPTION
The original code nodePath = "/" + nodePath; creates a new string object by concatenating the '/' character with the original value of nodePath. This operation involves allocating memory for the new string object and copying the characters of the original nodePath string.

On the other hand, the optimized code nodePath += "/"; directly modifies the original nodePath string, avoiding the creation of a new string object. This approach is more efficient as it reduces memory allocation and character copying operations.