### PR TITLE
package.properties shows changes

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/editors/pack/ContentsSection.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/editors/pack/ContentsSection.java
@@ -103,6 +103,10 @@ public class ContentsSection extends SectionPart {
         // Initialize TreeView
         if (mTreeViewer != null) {
             mTreeViewer.setInput(mPage.getProject());
+            // In order to bypass lazy loading and ensure the correct display of the tree,
+            // it is necessary to force the loading of the entire tree checkboxes state.
+            mTreeViewer.expandAll();
+            mTreeViewer.collapseAll();
         }
     }
 

--- a/core/source/org/libreoffice/ide/eclipse/core/model/pack/PackagePropertiesModel.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/model/pack/PackagePropertiesModel.java
@@ -858,11 +858,13 @@ public class PackagePropertiesModel {
         IResource[] members = parent.members();
         boolean all = true;
         boolean any = false;
+        int count = 0;
         for (IResource res : members) {
             // We need to consider only non-hidden resource
             if (isFilteredResource(res)) {
                 continue;
             }
+            count++;
             if (res.getType() == IResource.FILE) {
                 if (mFiles.contains(res)) {
                     any = true;
@@ -879,7 +881,7 @@ public class PackagePropertiesModel {
             }
         }
         if (isCheckStateSetable(folders, parent)) {
-            if (members.length == 0) {
+            if (count == 0) {
                 all = false;
             }
             setCheckState(folders, parent, all, any);
@@ -909,11 +911,13 @@ public class PackagePropertiesModel {
         IResource[] members = parent.members();
         boolean all = true;
         boolean any = false;
+        int count = 0;
         for (IResource res : members) {
             // We need to consider only non-hidden resource
             if (isFilteredResource(res)) {
                 continue;
             }
+            count++;
             if (res.getType() == IResource.FILE) {
                 if (mFiles.contains(res)) {
                     any = true;
@@ -928,7 +932,7 @@ public class PackagePropertiesModel {
                 }
             }
         }
-        if (members.length == 0) {
+        if (count == 0) {
             all = false;
         }
         setCheckState(mFolders, parent, all, any);
@@ -946,11 +950,11 @@ public class PackagePropertiesModel {
         return hasMembers;
     }
 
-    private void setCheckState(Map<IResource, Boolean> folders, IResource parent, boolean all, boolean any) {
+    private void setCheckState(Map<IResource, Boolean> folders, IResource res, boolean all, boolean any) {
         if (all || any) {
-            folders.put(parent, any && !all);
-        } else if (folders.containsKey(parent)) {
-            folders.remove(parent);
+            folders.put(res, any && !all);
+        } else if (folders.containsKey(res)) {
+            folders.remove(res);
         }
     }
 


### PR DESCRIPTION
Fix #133.
If we force the loading of the tree state during initialization (ie: expand all then collapse all), the display of the check boxes is correct.
It's the Eclipse or AWT API that is a bit lazy here.