### PR TITLE
Support for non-UNO projects

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizard.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizard.java
@@ -33,6 +33,7 @@ import java.io.File;
 import java.util.Iterator;
 
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.viewers.IStructuredSelection;
@@ -78,19 +79,17 @@ public class AntScriptExportWizard extends Wizard implements IExportWizard {
         // Try hard to find a selected UNO project
         IUnoidlProject prj = null;
         Iterator<?> it = selection.iterator();
-        while (it.hasNext() && prj == null) {
-            Object o = it.next();
-            if (o instanceof IAdaptable) {
-                IResource res = ((IAdaptable) o).getAdapter(IResource.class);
-                if (res != null) {
-                    prj = ProjectsManager.getProject(res.getProject().getName());
-                    String language = prj.getLanguage().getName();
-                    if (!language.equalsIgnoreCase("Java") || !language.equalsIgnoreCase("Python")) {
-                        prj = null;
+        try {
+            while (it.hasNext() && prj == null) {
+                Object o = it.next();
+                if (o instanceof IAdaptable) {
+                    IResource res = ((IAdaptable) o).getAdapter(IResource.class);
+                    if (res != null && res.getProject().hasNature(OOEclipsePlugin.UNO_NATURE_ID)) {
+                        prj = ProjectsManager.getProject(res.getProject().getName());
                     }
                 }
             }
-        }
+        } catch (CoreException e) { }
         setWindowTitle(Messages.getString("AntScriptExportWizard.DialogTitle")); //$NON-NLS-1$
 
         mAntScriptPage = new AntScriptExportWizardPage("page1", prj); //$NON-NLS-1$

--- a/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizardPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizardPage.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.wizard.WizardPage;
@@ -58,6 +59,7 @@ import org.libreoffice.ide.eclipse.core.model.IUnoidlProject;
 import org.libreoffice.ide.eclipse.core.model.ProjectsManager;
 import org.libreoffice.ide.eclipse.core.model.language.LanguageExportPart;
 import org.libreoffice.ide.eclipse.core.Messages;
+import org.libreoffice.ide.eclipse.core.OOEclipsePlugin;
 import org.libreoffice.plugin.core.model.UnoPackage;
 
 public class AntScriptExportWizardPage extends WizardPage {
@@ -157,22 +159,19 @@ public class AntScriptExportWizardPage extends WizardPage {
         lbl.setText(Messages.getString("AntScriptExportWizard.Project")); //$NON-NLS-1$
         lbl.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
 
-        IUnoidlProject[] prjs = ProjectsManager.getProjects();
-        ArrayList<String> tempPrjNames = new ArrayList<>();
-        for (int i = 0; i < prjs.length; i++) {
-            //The Dropdown for Ant Script should only have Java Uno Projects
-            String language = prjs[i].getLanguage().getName();
-            if (language.equalsIgnoreCase("Java") || language.equalsIgnoreCase("Python")) {
-                IUnoidlProject prj = prjs[i];
-                tempPrjNames.add(prj.getName());
+        ArrayList<String> prjs = new ArrayList<>();
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        try {
+            for (IUnoidlProject prj : ProjectsManager.getProjects()) {
+                if (root.getProject(prj.getName()).hasNature(OOEclipsePlugin.UNO_NATURE_ID)) {
+                    prjs.add(prj.getName());
+                }
             }
-        }
-        String[] prjNames = tempPrjNames.toArray(new String[tempPrjNames.size()]);
+        } catch (CoreException e) { }
 
         mProjectsList = new Combo(selectionBody, SWT.DROP_DOWN | SWT.READ_ONLY);
         mProjectsList.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-        mProjectsList.setItems(prjNames);
-
+        mProjectsList.setItems(prjs.toArray(new String[prjs.size()]));
         mProjectsList.addModifyListener(new ModifyListener() {
 
             @Override

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -32,9 +32,11 @@ package org.libreoffice.ide.eclipse.core.wizards.pages;
 
 import java.io.File;
 import java.text.MessageFormat;
+import java.util.ArrayList;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.dialogs.IDialogSettings;
@@ -165,16 +167,19 @@ public class UnoPackageExportPage extends WizardPage {
         lbl.setText(Messages.getString("UnoPackageExportPage.Project")); //$NON-NLS-1$
         lbl.setLayoutData(new GridData(SWT.BEGINNING, SWT.CENTER, false, false));
 
-        IUnoidlProject[] prjs = ProjectsManager.getProjects();
-        String[] prjNames = new String[prjs.length];
-        for (int i = 0; i < prjs.length; i++) {
-            IUnoidlProject prj = prjs[i];
-            prjNames[i] = prj.getName();
-        }
+        ArrayList<String> prjs = new ArrayList<>();
+        IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+        try {
+            for (IUnoidlProject prj : ProjectsManager.getProjects()) {
+                if (root.getProject(prj.getName()).hasNature(OOEclipsePlugin.UNO_NATURE_ID)) {
+                    prjs.add(prj.getName());
+                }
+            }
+        } catch (CoreException e) { }
 
         mProjectsList = new Combo(selectionBody, SWT.DROP_DOWN | SWT.READ_ONLY);
         mProjectsList.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, false));
-        mProjectsList.setItems(prjNames);
+        mProjectsList.setItems(prjs.toArray(new String[prjs.size()]));
 
         mProjectsList.addModifyListener(new ModifyListener() {
 


### PR DESCRIPTION
This is supposed to fix issue #137
Now only the [IProject](https://archive.eclipse.org/eclipse/downloads/documentation/2.0/html/plugins/org.eclipse.platform.doc.isv/reference/api/org/eclipse/core/resources/IProject.html) object is used to search for UNO nature projects.
