### PR TITLE
LOEclipse recognizes modular projects

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/internal/helpers/UnoidlProjectHelper.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/internal/helpers/UnoidlProjectHelper.java
@@ -242,12 +242,12 @@ public class UnoidlProjectHelper {
     /**
      * Set the project builders and run the build.
      *
-     * @param pUnoProject
+     * @param unoProject
      *            the project on which to set the builders
      */
-    public static void setProjectBuilders(IUnoidlProject pUnoProject) {
+    public static void setProjectBuilders(IUnoidlProject unoProject) {
 
-        UnoidlProject project = (UnoidlProject) pUnoProject;
+        UnoidlProject project = (UnoidlProject) unoProject;
         try {
             // Add the project builders
             project.setBuilders();
@@ -382,8 +382,8 @@ public class UnoidlProjectHelper {
                         Messages.getString("UnoidlProjectHelper.CreationErrorMessage")); //$NON-NLS-1$
                 }
             });
-            PluginLogger.error(Messages.getString("UnoidlProjectHelper.FolderCreationError") + sourcesDir, //$NON-NLS-1$
-                e);
+            String msg = Messages.getString("UnoidlProjectHelper.FolderCreationError"); //$NON-NLS-1$
+            PluginLogger.error(msg + sourcesDir, e);
         }
 
     }
@@ -482,7 +482,7 @@ public class UnoidlProjectHelper {
 
             UnoidlProject unoProject = (UnoidlProject) project.getNature(OOEclipsePlugin.UNO_NATURE_ID);
 
-            // TODO Allow custom configuration
+            // XXX Allow custom configuration
             createDefaultConfig(unoProject.getConfigFile());
 
             ProjectsManager.addProject(unoProject);

--- a/core/source/org/libreoffice/plugin/core/model/UnoPackage.java
+++ b/core/source/org/libreoffice/plugin/core/model/UnoPackage.java
@@ -357,7 +357,7 @@ public class UnoPackage {
      */
     public void addComponentFile(String pathInArchive, File file, String type) {
         if (!file.isFile()) {
-            throw new IllegalArgumentException("pFile [" + file + "] is not a file");
+            throw new IllegalArgumentException("File [" + file + "] is not a file");
         }
 
         pathInArchive = FilenameUtils.separatorsToUnix(pathInArchive);

--- a/java/source/org/libreoffice/ide/eclipse/java/registration/RegistrationHandler.java.tpl
+++ b/java/source/org/libreoffice/ide/eclipse/java/registration/RegistrationHandler.java.tpl
@@ -167,7 +167,7 @@ public class RegistrationHandler '{'
             try '{'
                 reader.close();
                 in.close();
-            } catch (Exception e) '{'};
+            } catch (Exception e) '{' }
         }
 
         return classes.toArray(new Class[classes.size()]);


### PR DESCRIPTION
If in Eclipse you have declared a Java version 9 or higher and there is a file named **module-info.java** in the source folder then Eclipse will automatically add the necessary libraries in the module path and no longer in the class path as for a non-modular project.

Similarly LOEclipse will add the necessary LibreOffice libraries in the module path if the project is modular.
Regarding the build of the oxt file, only the Ant script has been updated to take into account the creation of modular archives.

Fix issue #136 and issue #140