### PR TITLE
non-UNO project management

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizard.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizard.java
@@ -84,7 +84,10 @@ public class AntScriptExportWizard extends Wizard implements IExportWizard {
                 Object o = it.next();
                 if (o instanceof IAdaptable) {
                     IResource res = ((IAdaptable) o).getAdapter(IResource.class);
-                    if (res != null && res.getProject().hasNature(OOEclipsePlugin.UNO_NATURE_ID)) {
+                    if (res != null &&
+                        res.getProject().hasNature(OOEclipsePlugin.UNO_NATURE_ID) &&
+                        ProjectsManager.getProject(res.getProject().getName()).getLanguage() != null) {
+                        // TODO: We need to check if the project is configured correctly and notify
                         prj = ProjectsManager.getProject(res.getProject().getName());
                     }
                 }

--- a/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizardPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/export/AntScriptExportWizardPage.java
@@ -163,7 +163,9 @@ public class AntScriptExportWizardPage extends WizardPage {
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
         try {
             for (IUnoidlProject prj : ProjectsManager.getProjects()) {
-                if (root.getProject(prj.getName()).hasNature(OOEclipsePlugin.UNO_NATURE_ID)) {
+                if (root.getProject(prj.getName()).hasNature(OOEclipsePlugin.UNO_NATURE_ID) &&
+                    prj.getLanguage() != null) {
+                    // TODO: We need to check if the project is configured correctly and notify
                     prjs.add(prj.getName());
                 }
             }

--- a/core/source/org/libreoffice/ide/eclipse/core/export/build.xml.tpl
+++ b/core/source/org/libreoffice/ide/eclipse/core/export/build.xml.tpl
@@ -8,10 +8,10 @@
         ************************************************************
     -->
 
-    <fail message="Please build using Ant 1.8.0 or higher.">
+    <fail message="Please build using Ant 1.9.1 or higher.">
         <condition>
             <not>
-                <antversion atleast="1.8.0"/>
+                <antversion atleast="1.9.1"/>
             </not>
         </condition>
     </fail>

--- a/core/source/org/libreoffice/ide/eclipse/core/gui/rows/OOoRow.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/gui/rows/OOoRow.java
@@ -53,15 +53,15 @@ public class OOoRow extends AbstractConfigRow {
     /**
      * Constructor.
      *
-     * @param pParent
+     * @param parent
      *            the composite where to create the row
-     * @param pProperty
+     * @param property
      *            the property for the row events
-     * @param pToSelect
+     * @param toSelect
      *            the configuration element to select first
      */
-    public OOoRow(final Composite pParent, String pProperty, IOOo pToSelect) {
-        super(pParent, pProperty, Messages.getString("OOoRow.Browse"), pToSelect); //$NON-NLS-1$
+    public OOoRow(final Composite parent, String property, IOOo toSelect) {
+        super(parent, property, Messages.getString("OOoRow.Browse"), toSelect); //$NON-NLS-1$
     }
 
     /**
@@ -108,8 +108,8 @@ public class OOoRow extends AbstractConfigRow {
      * {@inheritDoc}
      */
     @Override
-    protected String getElementName(Object pToSelect) {
-        return ((IOOo) pToSelect).getName();
+    protected String getElementName(Object toSelect) {
+        return ((IOOo) toSelect).getName();
     }
 
     /**
@@ -124,8 +124,8 @@ public class OOoRow extends AbstractConfigRow {
      * {@inheritDoc}
      */
     @Override
-    protected AbstractTable createTable(Composite pParent) {
-        OOoTable table = new OOoTable(pParent);
+    protected AbstractTable createTable(Composite parent) {
+        OOoTable table = new OOoTable(parent);
         table.getPreferences();
 
         return table;

--- a/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
+++ b/core/source/org/libreoffice/ide/eclipse/core/wizards/pages/UnoPackageExportPage.java
@@ -171,7 +171,9 @@ public class UnoPackageExportPage extends WizardPage {
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
         try {
             for (IUnoidlProject prj : ProjectsManager.getProjects()) {
-                if (root.getProject(prj.getName()).hasNature(OOEclipsePlugin.UNO_NATURE_ID)) {
+                if (root.getProject(prj.getName()).hasNature(OOEclipsePlugin.UNO_NATURE_ID) &&
+                    prj.getLanguage() != null) {
+                    // TODO: We need to check if the project is configured correctly and notify
                     prjs.add(prj.getName());
                 }
             }

--- a/core/source/org/libreoffice/plugin/core/model/UnoPackage.java
+++ b/core/source/org/libreoffice/plugin/core/model/UnoPackage.java
@@ -379,7 +379,7 @@ public class UnoPackage {
      */
     public void addTypelibraryFile(String pathInArchive, File file) {
         if (!file.isFile()) {
-            throw new IllegalArgumentException("pFile [" + file + "] is not a file");
+            throw new IllegalArgumentException("File [" + file + "] is not a file");
         }
 
         pathInArchive = FilenameUtils.separatorsToUnix(pathInArchive);
@@ -552,7 +552,7 @@ public class UnoPackage {
      */
     public void addConfigurationDataFile(String pathInArchive, File file) {
         if (!file.isFile()) {
-            throw new IllegalArgumentException("pFile [" + file + "] is not a file");
+            throw new IllegalArgumentException("File [" + file + "] is not a file");
         }
 
         // Do not change the extension from now
@@ -572,7 +572,7 @@ public class UnoPackage {
      */
     public void addConfigurationSchemaFile(String pathInArchive, File file) {
         if (!file.isFile()) {
-            throw new IllegalArgumentException("file [" + file + "] is not a file");
+            throw new IllegalArgumentException("File [" + file + "] is not a file");
         }
 
         // Do not change the extension from now
@@ -594,7 +594,7 @@ public class UnoPackage {
      */
     public void addPackageDescription(String pathInArchive, File file, Locale locale) {
         if (!file.isFile()) {
-            throw new IllegalArgumentException("file [" + file + "] is not a file");
+            throw new IllegalArgumentException("File [" + file + "] is not a file");
         }
 
         mManifest.addDescription(pathInArchive, locale);
@@ -615,7 +615,7 @@ public class UnoPackage {
      */
     public void addOtherFile(String pPathInArchive, File file) {
         if (!file.isFile()) {
-            throw new IllegalArgumentException("file [" + file.getAbsolutePath() + "] is not a file");
+            throw new IllegalArgumentException("File [" + file.getAbsolutePath() + "] is not a file");
         }
 
         pPathInArchive = FilenameUtils.separatorsToUnix(pPathInArchive);


### PR DESCRIPTION
Fix issue #142 

- Only UNO projects and not configured by default will be listed in Eclipse.
- The Ant script requires version 1.9.1 minimum and will let you know if necessary.
- It is possible to change the SDK of any project.