### PR TITLE
Ant can build a non-modular Java project

### DIFF
--- a/core/source/org/libreoffice/ide/eclipse/core/export/build.xml.tpl
+++ b/core/source/org/libreoffice/ide/eclipse/core/export/build.xml.tpl
@@ -142,7 +142,7 @@
                 <available file="$'{'src.module}" type="file"/>
             </and>
         </condition>
-        <property unless:set="src.withmodule" name="src.withoutmodule"/>
+        <property unless:set="src.withmodule" name="src.withoutmodule" value="true"/>
 
         <echo if:set="src.withmodule" message="Compiling jar with module"/>
         <echo if:set="src.withoutmodule" message="Compiling jar without module"/>


### PR DESCRIPTION
This allows Ant to build non-modular Java projects and fix issue #147.